### PR TITLE
Hides github link from menubar

### DIFF
--- a/extra-files/click-to-copy.html
+++ b/extra-files/click-to-copy.html
@@ -5,6 +5,11 @@ Based on:
 -->
 <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
 <script>
+
+//Hides github from menubar
+$('a[title="Browse Repository"]').hide();
+
+/*create copy button when page loaded*/
 !function (e, t, a) {
   /* code */
   var initCopyCode = function(){


### PR DESCRIPTION
Remove DOCS GitHub link from menu-bar avoiding user confusion.

<img width="589" alt="Screenshot 2021-11-30 at 23 58 10" src="https://user-images.githubusercontent.com/79267265/144141910-df8f951b-45d2-40b5-b136-c9254fec1f91.png">

<img width="538" alt="Screenshot 2021-11-30 at 23 59 06" src="https://user-images.githubusercontent.com/79267265/144141916-ef6b575c-1911-41b4-b5d6-396c5d5b577a.png">

