### PR TITLE
showRecordCount is method on Footer

### DIFF
--- a/docs/table/features-setup.md
+++ b/docs/table/features-setup.md
@@ -183,7 +183,7 @@ Available modes:
 Example:
 
 ```php
-Header::showRecordCount(mode: 'full')
+Footer::showRecordCount(mode: 'full')
 ```
 
 Result:


### PR DESCRIPTION
This PR fixes a typo in the documentation. The `showRecordCount()` method in the `setUp` is not  a method on `Header` but on `Footer`.