### PR TITLE
Custom perPage and perPageValues need to be passed into showPerPage method

### DIFF
--- a/docs/table/features-setup.md
+++ b/docs/table/features-setup.md
@@ -151,14 +151,17 @@ If you need a different set of values, you may override the `$perPageValues` arr
 ```php
 class DishesTable extends PowerGridComponent
 {
+    //Custom per page
+    public int $perPage = 5;
+    
     //Custom per page values
-    public array $perPageValues = [0, 5, 10, 1000, 5000];
+    public array $perPageValues = [0, 5, 10, 20, 50];
 
     public function setUp(): array
     {
         return [
             Footer::make()
-                ->showPerPage()
+                ->showPerPage($this->perPage, $this->perPageValues)
         ]   
     }
     //....


### PR DESCRIPTION
This PR fixes docs where parameters were not passed into showPerPage and no customization was observed.