### PR TITLE
added behavior that changes the 'search' property

### DIFF
--- a/docs/table/add-columns.md
+++ b/docs/table/add-columns.md
@@ -133,8 +133,45 @@ public function columns(): PowerGridEloquent
        ->searchable()
        ->sortable(),
 }
+
 ```
 
+### Before Search
+beforeSearch can be run if you want to change the behavior of the ‘search’ property before performing the search within the PowerGrid.
+This is useful when we have to deal with the query before querying the database.
+
+
+For example, we have a phone field without a mask in the database, but the user types the search with a mask.
+With this PR you can process before removing the characters that do not need to be sent in the query
+
+```php
+<!-- ✅ Right -->
+
+public function columns()
+    {
+        return [
+            Column::make('Phone', 'phone_editable', 'phone')
+                  ->visibleInExport(false)
+                  ->headerAttribute('')
+                  ->bodyAttribute(''),
+        ];
+    }
+
+    public function beforeSearchPhone($search): string
+    {
+        return str($search)->replaceMatches('/[^0-9]+/', '')->toString();
+    }
+
+    public function beforeSearch(string $field = null, string $search = null)
+    {
+        if ($field === 'phone') {
+            return str($search)->replaceMatches('/[^0-9]+/', '')->toString();
+        }
+
+        return $search;
+    }
+
+```
 ## Closure Examples
 
 Sometimes, you need to display data in a human-friendly way.

--- a/docs/table/add-columns.md
+++ b/docs/table/add-columns.md
@@ -145,15 +145,12 @@ For example, we have a phone field without a mask in the database, but the user 
 With this PR you can process before removing the characters that do not need to be sent in the query
 
 ```php
-<!-- ✅ Right -->
 
 public function columns()
     {
         return [
             Column::make('Phone', 'phone_editable', 'phone')
-                  ->visibleInExport(false)
-                  ->headerAttribute('')
-                  ->bodyAttribute(''),
+                  ->searchable(),
         ];
     }
 


### PR DESCRIPTION
beforeSearch can be run if you want to change the behavior of the 'search' property before performing the search within the PowerGrid.