### PR TITLE
Added tip for html input in column title

### DIFF
--- a/docs/table/include-columns.md
+++ b/docs/table/include-columns.md
@@ -93,7 +93,7 @@ You can translate your title using Laravel's [translation strings](https://larav
 ::: tip
 The column title also accepts HTML input. 
 
-For example- if using fontawesome you can use this to insert icons instead of text.
+For example- if using a font icon package you can use this to insert icons instead of text.
 ```php{2}
     Column::add()
         ->title('<i class="fas fa-low-vision" title="Visibility"></i>')

--- a/docs/table/include-columns.md
+++ b/docs/table/include-columns.md
@@ -100,7 +100,7 @@ For example- if using a font icon package you can use this to insert icons inste
 ```
 
 **Warning:**
-Since column titles are unescaped HTML, you should not directly insert any inputs by users as it may be susceptible to XSS attacks. If you must put user input please escape user defined values using Laravel's [`e`](https://laravel.com/docs/10.x/helpers#method-e) helper
+Since column titles are unescaped HTML, you should not directly insert any inputs by users as it may be susceptible to XSS attacks. If you must put user input please escape user defined values using Laravel's [`e`](https://laravel.com/docs/strings#method-e) helper
 :::
 
 

--- a/docs/table/include-columns.md
+++ b/docs/table/include-columns.md
@@ -90,6 +90,21 @@ Column::add()
 You can translate your title using Laravel's [translation strings](https://laravel.com/docs/8.x/localization#retrieving-translation-strings) feature.
 :::
 
+::: tip
+The column title also accepts HTML input. 
+
+For example- if using fontawesome you can use this to insert icons instead of text.
+```php{2}
+    Column::add()
+        ->title('<i class="fas fa-low-vision" title="Visibility"></i>')
+```
+
+**Warning:**
+Since column titles are unescaped HTML, you should not directly insert any inputs by users as it may be susceptible to XSS attacks. If you must put user input please escape user defined values using Laravel's [`e`](https://laravel.com/docs/10.x/helpers#method-e) helper
+:::
+
+
+
 ---
 
 ### placeholder


### PR DESCRIPTION
This PR to the docs is for the PR https://github.com/Power-Components/livewire-powergrid/pull/1396#issuecomment-1932696797 which discusses the possibility of allowing unescaped HTML within the column title. This PR adds this as a tip and also adds a warning to let developers know not to make their column titles user input data.