### PR TITLE
Fix typo in component-columns doc

### DIFF
--- a/docs/table-component/component-columns.md
+++ b/docs/table-component/component-columns.md
@@ -93,7 +93,7 @@ class DishTable extends PowerGridComponent
             Column::make(
                     title: 'Discount Price', 
                     field: 'price_with_discount', 
-                    dateField: 'price'
+                    dataField: 'price'
             )
         ];
     }


### PR DESCRIPTION
Fix a small typo, parameter name is `dataField `instead of `dateField`