### PR TITLE
Document action column is not exported by default

### DIFF
--- a/docs/table-features/columns.md
+++ b/docs/table-features/columns.md
@@ -29,6 +29,7 @@ The Action Column is a dedicated column to display Row Actions such as [Buttons]
 To include an Action Column, just add a call to `Column::action()` in your Component's `columns()` method.
 
 Typically, the Action Column is the last column in your Table, however may add this column as many times as you want and at any desired position.
+If you deal with export, by default Action Column are not included but the method [`Column::visibleInExport()`](/table-component/component-columns.html#visibleinexport) can be used if you need them in your exported file.
 
 Example:
 

--- a/docs/table-features/exporting-data.md
+++ b/docs/table-features/exporting-data.md
@@ -66,6 +66,8 @@ Sometimes, it may be necessary to omit certain Columns when exporting data but s
 
 To implement this scenario, you should use the method [`Column::visibleInExport()`](/table-component/component-columns.html#visibleinexport) to control whether the column will be included in the export file and the method [`Column::hidden()`](/table-component/component-columns.html#hidden) to hide the column in the grid.
 
+By default, [Action Column](/table-features/columns.html#action-column) are not included in export, the method [`Column::visibleInExport()`](/table-component/component-columns.html#visibleinexport) will allow you to add them if you need.
+
 Using these two methods, you can create a column with [formatted data](/table-component/data-source-fields.html#formatting-data-examples), displayed in the grid but hidden in export, and a column with raw data hidden in the grid but included in the exported file.
 
 Example:


### PR DESCRIPTION
Documentation for [#1741](https://github.com/Power-Components/livewire-powergrid/pull/1741) in code - make column action no exportable by default