### PR TITLE
Updating docs to add a Note for Tailwind CSS when using custom theme

### DIFF
--- a/docs/expanding-powergrid/custom-theme.md
+++ b/docs/expanding-powergrid/custom-theme.md
@@ -211,3 +211,24 @@ class DishTable extends PowerGridComponent
         return \App\PowerGridThemes\BigFonts::class;
     }
 ```
+
+## Note for Tailwind CSS
+
+When using Tailwind CSS you may need to add your custom theme file to your Tailwind configuration as a content in order to scan your file for classes during the build process. The following shows an example of how to do so when using the above `app\PowerGridThemes\BigFonts.php` file as an example.
+
+1. Add the following file to your `tailwind.config.js` in the `content` key:
+
+```js
+module.exports = {
+    ...
+
+    content: [
+        '...',
+        './app/PowerGridThemes/BigFonts.php', // replace with path to your custom theme [!code ++]
+    ],
+
+    ...
+}
+```
+
+2. Rebuild your assets using `npm run build` or `npm run dev`.


### PR DESCRIPTION
This PR adds a note for Tailwind CSS for custom themes. When using a custom theme, a developer may add certain Tailwind classes which are not necessarily used in the usual blade files. Since Tailwind parses the `content` as configured in the `tailwind.config.js` to generate smaller files with only the classes used, we need to specifically let Tailwind know to check the custom theme file in such a case. This PR adds documentation on how to do so for Tailwind CSS users.