### PR TITLE
fix syntax issue in data source fields

### DIFF
--- a/docs/table-component/data-source-fields.md
+++ b/docs/table-component/data-source-fields.md
@@ -307,7 +307,7 @@ class SelectCategory extends Component
 </div>
 ```
 
-::: code-group
+:::
 
 <div class="onlinedemo custom-block">
   <p class="custom-block-title">🚀 See it in action</p>


### PR DESCRIPTION
Fix a syntax issue causing wrong display

![powergrid-codegroup](https://github.com/user-attachments/assets/2e0d1cc1-716a-493c-b689-e43d55bf6d1c)

From https://vitepress.dev/guide/markdown#code-groups 
Closing syntax is just `:::`