### PR TITLE
Add note to install OpenSpout on Exporting-data page

### DIFF
--- a/docs/table-features/exporting-data.md
+++ b/docs/table-features/exporting-data.md
@@ -6,6 +6,15 @@ Here you will find:
 
 [[toc]]
 
+## Install OpenSpout
+
+In order to use the export function, you must install the [OpenSpout package](https://github.com/openspout/openspout) v4.x. To do this run the following command in your terminal:
+
+
+```bash
+composer require openspout/openspout:^4.0
+```
+
 ## Enable Data Export
 
 To enable Data Exporting, follow the steps described below.


### PR DESCRIPTION
This PR adds a note to install OpenSpout on the Export Data page as it is a dependency for exporting the data. This part is missing so it was confusing to get started with the export. Others have reported similar problems in issues https://github.com/Power-Components/livewire-powergrid/issues/1318