### PR TITLE
Mention Table can be rendered from route

### DIFF
--- a/docs/get-started/rendering-a-powergrid-table.md
+++ b/docs/get-started/rendering-a-powergrid-table.md
@@ -47,6 +47,16 @@ For reference, the following example utilizes the class `app/Livewire/Tables/Dis
 <livewire:tables.dish-table /> // [!code ++]
 ```
 
+## From route
+
+If you do not need a Blade view, you can render your Table directly from route :
+
+```php
+// routes/web.php
+
+Route::get('/dish', DishTable::class)->name('dish-table'); // [!code ++]
+```
+
 ## Multiple Components Per Page
 
 To render more than one PowerGrid component on the same page, you must first assign a unique `TableName` to each component. Read more about [configuring table name](/table-component/component-configuration.html#table-name).


### PR DESCRIPTION
Hello

I don't remember how I discovered it but I noticed this is not mentioned in documentation
Maybe this is something obvious for regular Livewire users but I think this can be a useful addition in documentation, wdyt ? 