### PR TITLE
docs: clarify Tailwind CSS v4 support in features table

### DIFF
--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -14,7 +14,7 @@ PowerGrid offers a range of features that are readily available:
 
 | Feature                                                            | PowerGrid                               |
 | :--------------------------------------------------------------------- | :-------------------------------------- |
-| Bootstrap 5 or Tailwind CSS 3x                                         | ✅                                      |
+| Bootstrap 5 or Tailwind CSS 3x/4x                                      | ✅                                      |
 | Pagination                                                             | ✅                                      |
 | Column Sorting                                                         | ✅                                      |
 | Filters & Global Search                                                | ✅                                      |


### PR DESCRIPTION
Updates the features table to clarify support for Tailwind CSS v4.

The current documentation lists support for `Tailwind CSS 3x`, which is inconsistent with the repository's README and configuration pages that indicate support for `3x/4x`. This can cause confusion and lead users to think v4 is not supported.

This change aligns the features table with the rest of the documentation, providing a more accurate overview for users.