### PR TITLE
use camelCase for table name

### DIFF
--- a/docs/release-notes-and-upgrade/upgrade-guide.md
+++ b/docs/release-notes-and-upgrade/upgrade-guide.md
@@ -27,8 +27,8 @@ New tables will have a pre-configured name via the `powergrid:create` command.
 
 ```php
 public string $tableName = 'default';// [!code --]
-public string $tableName = 'users-table'; // [!code ++]
-// Ex: admin-users-table, dishes, category-table 
+public string $tableName = 'usersTable'; // [!code ++]
+// Ex: adminUsersTable, dishesTable, categoryTable 
 ```
 
 ## JS Imports

--- a/docs/table-component/component-configuration.md
+++ b/docs/table-component/component-configuration.md
@@ -25,7 +25,7 @@ use PowerComponents\LivewirePowerGrid\PowerGridComponent;
 
 class DishTable extends PowerGridComponent
 {
-    public string $tableName = 'DishTable';// [!code ++]
+    public string $tableName = 'dishTable';// [!code ++]
 }
 ````
 


### PR DESCRIPTION
Use camelCase in documentation for table name attribute
Following [this discussion](https://github.com/Power-Components/livewire-powergrid/discussions/2030) in code repo